### PR TITLE
Update install.js

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -26,7 +26,7 @@ function install() {
         }
 
         const ext =  platform === "windows" ? ".exe" : "";
-        const arch = process.arch.includes("arm") ? "arm" : "amd64";
+        const arch = process.arch.includes("arm") ? "arm64" : "amd64";
         const url = releaseFor(version, platform, arch) + ext;
         const cli = join(__dirname, "..", "bin", "ytt-cli" + ext);
 


### PR DESCRIPTION
Bugfix: `arm` > `arm64`. Name of reasource on carvel-ytt is `ytt-{arch}-arm64`.

**[Carvel YTT Releases](https://github.com/vmware-tanzu/carvel-ytt/releases)**

<img width="888" alt="image" src="https://user-images.githubusercontent.com/47827286/168824995-01eb57d1-9229-45f2-b023-86a7c22a5d43.png">